### PR TITLE
Add db seed script, added axios, dynamic product data

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ To start MongoDB Server:
 ```
 start: docker compose up
 stop: docker compose down
+seed database: yarn seed
 ```
 
 ## Tech Stack

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "ecommerce",
       "version": "0.1.0",
       "dependencies": {
+        "axios": "^1.1.2",
         "bcrypt": "^5.1.0",
         "jsonwebtoken": "^8.5.1",
         "mongoose": "^6.3.0",
@@ -894,6 +895,11 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.4",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.4.tgz",
@@ -935,6 +941,16 @@
       "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.1.2.tgz",
+      "integrity": "sha512-bznQyETwElsXl2RK7HLLwb5GPpOLlycxHCtrpDR/4RqqBzjARaOTo3jz4IgtntWUYee7Ne4S8UHd92VCuzPaWA==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -1223,6 +1239,17 @@
         "color-support": "bin.js"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1338,6 +1365,14 @@
       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
       "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
       "dev": true
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/delegates": {
       "version": "1.0.0",
@@ -2084,6 +2119,38 @@
       "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/fraction.js": {
       "version": "4.2.0",
@@ -2963,6 +3030,25 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -3683,6 +3769,11 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/punycode": {
       "version": "2.1.1",
@@ -5089,6 +5180,11 @@
       "integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0=",
       "dev": true
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
     "autoprefixer": {
       "version": "10.4.4",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.4.tgz",
@@ -5108,6 +5204,16 @@
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.1.tgz",
       "integrity": "sha512-gd1kmb21kwNuWr6BQz8fv6GNECPBnUasepcoLbekws23NVBLODdsClRZ+bQ8+9Uomf3Sm3+Vwn0oYG9NvwnJCw==",
       "dev": true
+    },
+    "axios": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.1.2.tgz",
+      "integrity": "sha512-bznQyETwElsXl2RK7HLLwb5GPpOLlycxHCtrpDR/4RqqBzjARaOTo3jz4IgtntWUYee7Ne4S8UHd92VCuzPaWA==",
+      "requires": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
     },
     "axobject-query": {
       "version": "2.2.0",
@@ -5282,6 +5388,14 @@
       "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
       "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
     },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -5362,6 +5476,11 @@
       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
       "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
       "dev": true
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
     "delegates": {
       "version": "1.0.0",
@@ -5930,6 +6049,21 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
       "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
       "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
+    },
+    "form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      }
     },
     "fraction.js": {
       "version": "4.2.0",
@@ -6539,6 +6673,19 @@
         "picomatch": "^2.3.1"
       }
     },
+    "mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
+    },
+    "mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "requires": {
+        "mime-db": "1.52.0"
+      }
+    },
     "minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -7008,6 +7155,11 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
+    },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "punycode": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -6,9 +6,11 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "seed": "node --trace-warnings  scripts/fillDbDummyData.mjs"
   },
   "dependencies": {
+    "axios": "^1.1.2",
     "bcrypt": "^5.1.0",
     "jsonwebtoken": "^8.5.1",
     "mongoose": "^6.3.0",

--- a/pages/hoodies.js
+++ b/pages/hoodies.js
@@ -1,8 +1,8 @@
-import React from "react";
-import Link from "next/link";
-import mongoose from "mongoose";
-import Image from "next/image";
-import Product from "../models/Product";
+import React from 'react';
+import Link from 'next/link';
+import mongoose from 'mongoose';
+import Image from 'next/image';
+import Product from '../models/Product';
 
 const Hoodies = ({ products }) => {
   return (
@@ -13,7 +13,7 @@ const Hoodies = ({ products }) => {
             {products.map((item) => {
               return (
                 <div className="lg:w-1/4 md:w-1/2 p-4 w-full" key={item._id}>
-                  <Link href={"/products/hoodies"}>
+                  <Link href={`/products/${item.slug}`}>
                     <a className="block relative h-48 rounded overflow-hidden">
                       <Image
                         alt="ecommerce"
@@ -46,7 +46,7 @@ export async function getServerSideProps(context) {
   if (!mongoose.connections[0].readyState) {
     await mongoose.connect(process.env.MONGO_URI);
   }
-  let products = await Product.find({category: 'hoodies'});
+  let products = await Product.find({ category: 'hoodies' });
   return {
     props: { products: JSON.parse(JSON.stringify(products)) }, // will be passed to the page component as props
   };

--- a/pages/products/[slug].js
+++ b/pages/products/[slug].js
@@ -1,93 +1,205 @@
-import { useRouter } from 'next/router'
+import { useRouter } from 'next/router';
+import Product from '../../models/Product';
+import mongoose from 'mongoose';
 
-const Post = ({addToCart}) => {
-  const router = useRouter()
-  const { slug } = router.query
+const Post = ({ addToCart, product }) => {
+  const { title, desc, img, category, price, availableQty, size, color } =
+    product[0];
+  const router = useRouter();
+  const { slug } = router.query;
 
-  return <>
-    <section className="text-gray-600 body-font overflow-hidden">
-      <div className="container px-5 py-16 mx-auto">
-        <div className="lg:w-4/5 mx-auto flex flex-wrap">
-          <img alt="ecommerce" className="lg:w-1/2 w-full lg:h-auto h-full px-28 object-cover object-top rounded" src="https://m.media-amazon.com/images/I/61R0oSuKMLL._AC_UX569_.jpg" />
-          <div className="lg:w-1/2 w-full lg:pl-10 lg:py-6 mt-6 lg:mt-0">
-            <h2 className="text-sm title-font text-gray-500 tracking-widest">Under Armour</h2>
-            <h1 className="text-gray-900 text-3xl title-font font-medium mb-1">Under Armour Men&apos;s Fast Left Chest 2.0 Short-Sleeve T-Shirt</h1>
-            <div className="flex mb-4">
-              <span className="flex items-center">
-                <svg fill="currentColor" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" className="w-4 h-4 text-indigo-500" viewBox="0 0 24 24">
-                  <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"></path>
-                </svg>
-                <svg fill="currentColor" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" className="w-4 h-4 text-indigo-500" viewBox="0 0 24 24">
-                  <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"></path>
-                </svg>
-                <svg fill="currentColor" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" className="w-4 h-4 text-indigo-500" viewBox="0 0 24 24">
-                  <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"></path>
-                </svg>
-                <svg fill="currentColor" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" className="w-4 h-4 text-indigo-500" viewBox="0 0 24 24">
-                  <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"></path>
-                </svg>
-                <svg fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" className="w-4 h-4 text-indigo-500" viewBox="0 0 24 24">
-                  <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"></path>
-                </svg>
-                <span className="text-gray-600 ml-3">4 Reviews</span>
-              </span>
-              <span className="flex ml-3 pl-3 py-2 border-l-2 border-gray-200 space-x-2s">
-                <a className="text-gray-500">
-                  <svg fill="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" className="w-5 h-5" viewBox="0 0 24 24">
-                    <path d="M18 2h-3a5 5 0 00-5 5v3H7v4h3v8h4v-8h3l1-4h-4V7a1 1 0 011-1h3z"></path>
+  return (
+    <>
+      <section className="text-gray-600 body-font overflow-hidden">
+        <div className="container px-5 py-16 mx-auto">
+          <div className="lg:w-4/5 mx-auto flex flex-wrap relative">
+            <img
+              alt={title}
+              className="lg:w-1/2 w-full lg:h-auto h-full px-28 object-cover object-top rounded"
+              src={img}
+            />
+            <div className="lg:w-1/2 w-full lg:pl-10 lg:py-6 mt-6 lg:mt-0">
+              <h2 className="text-sm title-font text-gray-500 tracking-widest">
+                Under Armour
+              </h2>
+              <h1 className="text-gray-900 text-3xl title-font font-medium mb-1">
+                {title}
+              </h1>
+              <div className="flex mb-4">
+                <span className="flex items-center">
+                  <svg
+                    fill="currentColor"
+                    stroke="currentColor"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth="2"
+                    className="w-4 h-4 text-indigo-500"
+                    viewBox="0 0 24 24"
+                  >
+                    <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"></path>
                   </svg>
-                </a>
-                <a className="text-gray-500">
-                  <svg fill="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" className="w-5 h-5" viewBox="0 0 24 24">
-                    <path d="M23 3a10.9 10.9 0 01-3.14 1.53 4.48 4.48 0 00-7.86 3v1A10.66 10.66 0 013 4s-4 9 5 13a11.64 11.64 0 01-7 2c9 5 20 0 20-11.5a4.5 4.5 0 00-.08-.83A7.72 7.72 0 0023 3z"></path>
+                  <svg
+                    fill="currentColor"
+                    stroke="currentColor"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth="2"
+                    className="w-4 h-4 text-indigo-500"
+                    viewBox="0 0 24 24"
+                  >
+                    <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"></path>
                   </svg>
-                </a>
-                <a className="text-gray-500">
-                  <svg fill="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" className="w-5 h-5" viewBox="0 0 24 24">
-                    <path d="M21 11.5a8.38 8.38 0 01-.9 3.8 8.5 8.5 0 01-7.6 4.7 8.38 8.38 0 01-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 01-.9-3.8 8.5 8.5 0 014.7-7.6 8.38 8.38 0 013.8-.9h.5a8.48 8.48 0 018 8v.5z"></path>
+                  <svg
+                    fill="currentColor"
+                    stroke="currentColor"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth="2"
+                    className="w-4 h-4 text-indigo-500"
+                    viewBox="0 0 24 24"
+                  >
+                    <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"></path>
                   </svg>
-                </a>
-              </span>
-            </div>
-            <p className="leading-relaxed">Fam locavore kickstarter distillery. Mixtape chillwave tumeric sriracha taximy chia microdosing tilde DIY. XOXO fam indxgo juiceramps cornhole raw denim forage brooklyn. Everyday carry +1 seitan poutine tumeric. Gastropub blue bottle austin listicle pour-over, neutra jean shorts keytar banjo tattooed umami cardigan.</p>
-            <div className="flex mt-6 items-center pb-5 border-b-2 border-gray-100 mb-5">
-              <div className="flex">
-                <span className="mr-3">Color</span>
-                <button className="border-2 border-gray-300 rounded-full w-6 h-6 focus:outline-none"></button>
-                <button className="border-2 border-gray-300 ml-1 bg-gray-700 rounded-full w-6 h-6 focus:outline-none"></button>
-                <button className="border-2 border-gray-300 ml-1 bg-indigo-500 rounded-full w-6 h-6 focus:outline-none"></button>
-              </div>
-              <div className="flex ml-6 items-center">
-                <span className="mr-3">Size</span>
-                <div className="relative">
-                  <select className="rounded border appearance-none border-gray-300 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-200 focus:border-indigo-500 text-base pl-3 pr-10">
-                    <option>SM</option>
-                    <option>M</option>
-                    <option>L</option>
-                    <option>XL</option>
-                  </select>
-                  <span className="absolute right-0 top-0 h-full w-10 text-center text-gray-600 pointer-events-none flex items-center justify-center">
-                    <svg fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" className="w-4 h-4" viewBox="0 0 24 24">
-                      <path d="M6 9l6 6 6-6"></path>
+                  <svg
+                    fill="currentColor"
+                    stroke="currentColor"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth="2"
+                    className="w-4 h-4 text-indigo-500"
+                    viewBox="0 0 24 24"
+                  >
+                    <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"></path>
+                  </svg>
+                  <svg
+                    fill="none"
+                    stroke="currentColor"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth="2"
+                    className="w-4 h-4 text-indigo-500"
+                    viewBox="0 0 24 24"
+                  >
+                    <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"></path>
+                  </svg>
+                  <span className="text-gray-600 ml-3">4 Reviews</span>
+                </span>
+                <span className="flex ml-3 pl-3 py-2 border-l-2 border-gray-200 space-x-2s">
+                  <a className="text-gray-500">
+                    <svg
+                      fill="currentColor"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth="2"
+                      className="w-5 h-5"
+                      viewBox="0 0 24 24"
+                    >
+                      <path d="M18 2h-3a5 5 0 00-5 5v3H7v4h3v8h4v-8h3l1-4h-4V7a1 1 0 011-1h3z"></path>
                     </svg>
-                  </span>
+                  </a>
+                  <a className="text-gray-500">
+                    <svg
+                      fill="currentColor"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth="2"
+                      className="w-5 h-5"
+                      viewBox="0 0 24 24"
+                    >
+                      <path d="M23 3a10.9 10.9 0 01-3.14 1.53 4.48 4.48 0 00-7.86 3v1A10.66 10.66 0 013 4s-4 9 5 13a11.64 11.64 0 01-7 2c9 5 20 0 20-11.5a4.5 4.5 0 00-.08-.83A7.72 7.72 0 0023 3z"></path>
+                    </svg>
+                  </a>
+                  <a className="text-gray-500">
+                    <svg
+                      fill="currentColor"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth="2"
+                      className="w-5 h-5"
+                      viewBox="0 0 24 24"
+                    >
+                      <path d="M21 11.5a8.38 8.38 0 01-.9 3.8 8.5 8.5 0 01-7.6 4.7 8.38 8.38 0 01-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 01-.9-3.8 8.5 8.5 0 014.7-7.6 8.38 8.38 0 013.8-.9h.5a8.48 8.48 0 018 8v.5z"></path>
+                    </svg>
+                  </a>
+                </span>
+              </div>
+              <p className="leading-relaxed">{desc}</p>
+              <div className="flex mt-6 items-center pb-5 border-b-2 border-gray-100 mb-5">
+                <div className="flex">
+                  <span className="mr-3">Color</span>
+                  <button className="border-2 border-gray-300 rounded-full w-6 h-6 focus:outline-none"></button>
+                  <button className="border-2 border-gray-300 ml-1 bg-gray-700 rounded-full w-6 h-6 focus:outline-none"></button>
+                  <button className="border-2 border-gray-300 ml-1 bg-indigo-500 rounded-full w-6 h-6 focus:outline-none"></button>
+                </div>
+                <div className="flex ml-6 items-center">
+                  <span className="mr-3">Size</span>
+                  <div className="relative">
+                    <select className="rounded border appearance-none border-gray-300 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-200 focus:border-indigo-500 text-base pl-3 pr-10">
+                      <option>SM</option>
+                      <option>M</option>
+                      <option>L</option>
+                      <option>XL</option>
+                    </select>
+                    <span className="absolute right-0 top-0 h-full w-10 text-center text-gray-600 pointer-events-none flex items-center justify-center">
+                      <svg
+                        fill="none"
+                        stroke="currentColor"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth="2"
+                        className="w-4 h-4"
+                        viewBox="0 0 24 24"
+                      >
+                        <path d="M6 9l6 6 6-6"></path>
+                      </svg>
+                    </span>
+                  </div>
                 </div>
               </div>
-            </div>
-            <div className="flex">
-              <span className="title-font font-medium text-2xl text-gray-900">$58.00</span>
-              <button onClick={()=>{addToCart(slug,1,'500','T-shirt Black','SM','Black')}} className="flex ml-auto text-white bg-gradient-to-r from-indigo-500 to-blue-500 shadow-lg shadow-indigo-600/50 border-0 py-2 px-6 focus:outline-none hover:bg-indigo-600 rounded">Add to Cart</button>
-              <button className="rounded-full w-10 h-10 bg-gray-200 p-0 border-0 inline-flex items-center justify-center text-gray-500 ml-4">
-                <svg fill="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" className="w-5 h-5" viewBox="0 0 24 24">
-                  <path d="M20.84 4.61a5.5 5.5 0 00-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 00-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 000-7.78z"></path>
-                </svg>
-              </button>
+              <div className="flex">
+                <span className="title-font font-medium text-2xl text-gray-900">
+                  ${price}
+                </span>
+                <button
+                  onClick={() => {
+                    addToCart(slug, 1, '500', 'T-shirt Black', 'SM', 'Black');
+                  }}
+                  className="flex ml-auto text-white bg-gradient-to-r from-indigo-500 to-blue-500 shadow-lg shadow-indigo-600/50 border-0 py-2 px-6 focus:outline-none hover:bg-indigo-600 rounded"
+                >
+                  Add to Cart
+                </button>
+                <button className="rounded-full w-10 h-10 bg-gray-200 p-0 border-0 inline-flex items-center justify-center text-gray-500 ml-4">
+                  <svg
+                    fill="currentColor"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth="2"
+                    className="w-5 h-5"
+                    viewBox="0 0 24 24"
+                  >
+                    <path d="M20.84 4.61a5.5 5.5 0 00-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 00-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 000-7.78z"></path>
+                  </svg>
+                </button>
+              </div>
             </div>
           </div>
         </div>
-      </div>
-    </section>
-  </>
-}
+      </section>
+    </>
+  );
+};
 
-export default Post
+export default Post;
+
+export async function getServerSideProps(context) {
+  if (!mongoose.connections[0].readyState) {
+    await mongoose.connect(process.env.MONGO_URI);
+  }
+
+  const itemSlug = context.params.slug;
+  let products = await Product.find({ slug: itemSlug });
+
+  return {
+    props: { product: JSON.parse(JSON.stringify(products)) }, // will be passed to the page component as props
+  };
+}

--- a/pages/stickers.js
+++ b/pages/stickers.js
@@ -1,8 +1,8 @@
-import React from "react";
-import Link from "next/link";
-import mongoose from "mongoose";
-import Image from "next/image";
-import Product from "../models/Product";
+import React from 'react';
+import Link from 'next/link';
+import mongoose from 'mongoose';
+import Image from 'next/image';
+import Product from '../models/Product';
 
 const Stickers = ({ products }) => {
   return (
@@ -13,7 +13,7 @@ const Stickers = ({ products }) => {
             {products.map((item) => {
               return (
                 <div className="lg:w-1/4 md:w-1/2 p-4 w-full" key={item._id}>
-                  <Link href={"/products/stickers"}>
+                  <Link href={`/products/${item.slug}`}>
                     <a className="block relative h-48 rounded overflow-hidden">
                       <Image
                         alt="ecommerce"
@@ -46,7 +46,7 @@ export async function getServerSideProps(context) {
   if (!mongoose.connections[0].readyState) {
     await mongoose.connect(process.env.MONGO_URI);
   }
-  let products = await Product.find({category: 'stickers'});
+  let products = await Product.find({ category: 'stickers' });
   return {
     props: { products: JSON.parse(JSON.stringify(products)) }, // will be passed to the page component as props
   };

--- a/pages/tshirts.js
+++ b/pages/tshirts.js
@@ -1,8 +1,8 @@
-import React from "react";
-import Link from "next/link";
-import mongoose from "mongoose";
-import Image from "next/image";
-import Product from "../models/Product";
+import React from 'react';
+import Link from 'next/link';
+import mongoose from 'mongoose';
+import Image from 'next/image';
+import Product from '../models/Product';
 
 const Tshirts = ({ products }) => {
   return (
@@ -13,7 +13,7 @@ const Tshirts = ({ products }) => {
             {products.map((item) => {
               return (
                 <div className="lg:w-1/4 md:w-1/2 p-4 w-full" key={item._id}>
-                  <Link href={"/products/tshirts"}>
+                  <Link href={`/products/${item.slug}`}>
                     <a className="block relative h-48 rounded overflow-hidden">
                       <Image
                         alt="ecommerce"
@@ -46,7 +46,7 @@ export async function getServerSideProps(context) {
   if (!mongoose.connections[0].readyState) {
     await mongoose.connect(process.env.MONGO_URI);
   }
-  let products = await Product.find({category: 't-shirts'});
+  let products = await Product.find({ category: 't-shirts' });
   return {
     props: { products: JSON.parse(JSON.stringify(products)) }, // will be passed to the page component as props
   };

--- a/pages/watches.js
+++ b/pages/watches.js
@@ -1,8 +1,8 @@
-import React from "react";
-import Link from "next/link";
-import mongoose from "mongoose";
-import Image from "next/image";
-import Product from "../models/Product";
+import React from 'react';
+import Link from 'next/link';
+import mongoose from 'mongoose';
+import Image from 'next/image';
+import Product from '../models/Product';
 
 const Watches = ({ products }) => {
   return (
@@ -13,7 +13,7 @@ const Watches = ({ products }) => {
             {products.map((item) => {
               return (
                 <div className="lg:w-1/4 md:w-1/2 p-4 w-full" key={item._id}>
-                  <Link href={"/products/watches"}>
+                  <Link href={`/products/${item.slug}`}>
                     <a className="block relative h-48 rounded overflow-hidden">
                       <Image
                         alt="ecommerce"
@@ -46,7 +46,7 @@ export async function getServerSideProps(context) {
   if (!mongoose.connections[0].readyState) {
     await mongoose.connect(process.env.MONGO_URI);
   }
-  let products = await Product.find({category: 'watches'});
+  let products = await Product.find({ category: 'watches' });
   return {
     props: { products: JSON.parse(JSON.stringify(products)) }, // will be passed to the page component as props
   };

--- a/scripts/fillDbDummyData.mjs
+++ b/scripts/fillDbDummyData.mjs
@@ -1,0 +1,109 @@
+import axios from 'axios';
+
+const fillDbWithDummyData = async () => {
+  const dummyProductData = [
+    {
+      title: `Gildan Men's Ultra Cotton T-Shirt`,
+      slug: 't-shirt1',
+      desc: '100% cotton, this classic fit preshrunk jersey knit provides unmatched comfort with each wear.',
+      img: '/tshirt.jpg',
+      category: 't-shirts',
+      price: '55',
+      availableQty: '132',
+      size: 'large',
+      color: 'black',
+    },
+    {
+      title: `Gildan Womens's Ultra Cotton T-Shirt`,
+      slug: 't-shirt2',
+      desc: '100% cotton, this classic fit preshrunk jersey knit provides unmatched comfort with each wear.',
+      img: '/tshirt.jpg',
+      category: 't-shirts',
+      price: '55',
+      availableQty: '132',
+      size: 'large',
+      color: 'black',
+    },
+    {
+      title: `Gildan Childrens's Ultra Cotton T-Shirt`,
+      slug: 't-shirt3',
+      desc: '100% cotton, this classic fit preshrunk jersey knit provides unmatched comfort with each wear.',
+      img: '/tshirt.jpg',
+      category: 't-shirts',
+      price: '55',
+      availableQty: '132',
+      size: 'large',
+      color: 'black',
+    },
+    {
+      title: 'Gildan Adult Fleece Hoodie',
+      slug: 'hoodie1',
+      desc: 'Equal parts durable, comfortable and stylish, the Gildan Adult Fleece Hooded Sweatshirt belongs in every collection.',
+      img: '/hoodies.jpg',
+      category: 'hoodies',
+      price: '100',
+      availableQty: '555',
+      size: 'large',
+      color: 'black',
+    },
+    {
+      title: `Gildan Children's Fleece Hoodie`,
+      slug: 'hoodie2',
+      desc: 'Equal parts durable, comfortable and stylish, the Gildan Adult Fleece Hooded Sweatshirt belongs in every collection.',
+      img: '/hoodies.jpg',
+      category: 'hoodies',
+      price: '100',
+      availableQty: '555',
+      size: 'large',
+      color: 'black',
+    },
+    {
+      title: `Fossil Men's Quartz Chronograph Watch`,
+      slug: 'watch1',
+      desc: 'Military-inspired design with oversized lugs and bold details offers a laid-back yet rugged feel that is perfect for any adventure, day or night.',
+      img: '/watches.jpg',
+      category: 'watches',
+      price: '200',
+      availableQty: '34',
+      size: null,
+      color: null,
+    },
+    {
+      title: `Fossil Women's Quartz Chronograph Watch`,
+      slug: 'watch2',
+      desc: 'Military-inspired design with oversized lugs and bold details offers a laid-back yet rugged feel that is perfect for any adventure, day or night.',
+      img: '/watches.jpg',
+      category: 'watches',
+      price: '200',
+      availableQty: '34',
+      size: null,
+      color: null,
+    },
+    {
+      title: 'Goku and Vegeta Sticker',
+      slug: 'sticker1',
+      desc: 'High quality decal die-cut laptop sticker in black color.',
+      img: '/stickers.jpg',
+      category: 'stickers',
+      price: '12',
+      availableQty: '117',
+      size: null,
+      color: null,
+    },
+  ];
+
+  try {
+    const response = await axios({
+      url: 'http://localhost:3000/api/addproduct',
+      method: 'post',
+      data: dummyProductData,
+    });
+
+    console.log('DB FILL SCRIPT SUCCESS');
+    return response.data;
+  } catch (error) {
+    console.log('FILL SCRIPT FAILED -->', error);
+  }
+};
+
+fillDbWithDummyData();


### PR DESCRIPTION
Issue #29 

1. I added a seed script that can be called using `yarn seed`.
2. Added axios, which is used in seed script
3. When you are looking at products under categories, when you click on a product, you will now be taken to the appropriate slug.

![viewing-categories](https://user-images.githubusercontent.com/61209222/195275334-015b8ca5-c4d8-450e-84fb-d35fce7573c6.png)

![viewing-product](https://user-images.githubusercontent.com/61209222/195275342-9e271ca6-64a9-4cf3-a606-d5f5682c992a.png)

5. Some dynamic data rendered at product slug ex: "/products/watch2". *** Not all data as some schema changes might be desired to stay consistent with things like a brand name. Not sure how this wants to be handles further down the line, so I added dynamic data that made sense for the time being.
6. In this same thought, feel free to make edits to the mock data, I followed the current schema and made some assumptions.
7. I forgot to ignore prettier, but I then added the prettier config that has been proposed, so files are saved with such prettier settings. I can change this back if necessary. +1 for pretter config.